### PR TITLE
Fix rectangle boundaries for macOS 11 Big Sur

### DIFF
--- a/WhichSpace/Classes/StatusItemCell.swift
+++ b/WhichSpace/Classes/StatusItemCell.swift
@@ -34,11 +34,14 @@ class StatusItemCell: NSStatusBarButtonCell {
             rectPath.fill()
         }
         
-        let roundedRectanglePath = NSBezierPath(roundedRect: NSRect(x: 5, y: 3, width: 16, height: 16), xRadius: 2, yRadius: 2)
+        let xStart = (controlView.frame.width - 16) / 2 + 2,
+            yStart = (controlView.frame.height - 16) / 2
+        
+        let roundedRectanglePath = NSBezierPath(roundedRect: NSRect(x: xStart, y: yStart, width: 16, height: 16), xRadius: 2, yRadius: 2)
         backgroundColor.setFill()
         roundedRectanglePath.fill()
         
-        let titleRect = NSRect(x: frame.origin.x, y: frame.origin.y + 3, width: frame.size.width, height: frame.size.height)
+        let titleRect = NSRect(x: frame.origin.x, y: frame.origin.y+5, width: frame.size.width, height: frame.size.height)
         
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = NSTextAlignment.center


### PR DESCRIPTION
Hi @gechr,

thanks for the widget - it is very helpful. I adjusted it for macOS 11:

![Screenshot 2021-06-11 at 23 13 21](https://user-images.githubusercontent.com/1571309/121753629-ab5c5a80-cb0a-11eb-998b-b711c5d98411.png)

I tried to have it find the rectangle start point dynamically - but I can't test it on macOS <11 nor I have Cocoa experience, so I'd be grateful if someone checked this.